### PR TITLE
Include the URL in the upload message

### DIFF
--- a/packages/replay/src/main.js
+++ b/packages/replay/src/main.js
@@ -317,7 +317,10 @@ async function doUploadRecording(
   connectionProcessRecording(recordingId);
   await connectionUploadRecording(recordingId, contents);
   addRecordingEvent(dir, "uploadFinished", recording.id);
-  maybeLog(verbose, "Upload finished.");
+  maybeLog(
+    verbose,
+    `Upload finished! View your Replay at: https://app.replay.io/recording/${recordingId}`
+  );
   closeConnection();
   return recordingId;
 }


### PR DESCRIPTION
I don't know if this will break our E2E test suites on devtools/backend, since they parse this output sometimes to find successes? Also, maybe there is more clean-up to do here, adding emojis or fancier ASCII or something?